### PR TITLE
Fix SheetOptions's init access control

### DIFF
--- a/Sources/Manager/SheetOptions.swift
+++ b/Sources/Manager/SheetOptions.swift
@@ -47,6 +47,8 @@ public struct ToolBarItem {
 
 public struct SheetOptions {
     
+    public init() { }
+    
     // Button
     /// Sheet ToolBar Background Color
     public var defaultToolBarBackgroundColor: UIColor = .black


### PR DESCRIPTION

AS-IS
 - SheetOptions's init access control is internal

TO-BE
 - SheetOptions's init access control will be changed to public