### PR TITLE
fix update topMargin for not full screen present

### DIFF
--- a/Sources/Controller/SheetContentsViewController.swift
+++ b/Sources/Controller/SheetContentsViewController.swift
@@ -149,7 +149,7 @@ private extension SheetContentsViewController {
         let contentHeight = collectionView?.contentSize.height ?? 0
         let visibleHeight = min(contentHeight - layout.settings.topMargin, visibleContentsHeight)
         
-        topMargin = isFullScreenContent ? 0 : max(screenHeight - layout.settings.minMargin - visibleHeight - bottomToolBarHeight, 0)
+        topMargin = isFullScreenContent ? 0 : max(screenHeight - layout.settings.minTopMargin - visibleHeight - bottomToolBarHeight, 0)
         layout.settings.topMargin = topMargin
     }
 

--- a/Sources/Controller/SheetContentsViewController.swift
+++ b/Sources/Controller/SheetContentsViewController.swift
@@ -149,7 +149,7 @@ private extension SheetContentsViewController {
         let contentHeight = collectionView?.contentSize.height ?? 0
         let visibleHeight = min(contentHeight - layout.settings.topMargin, visibleContentsHeight)
         
-        topMargin = isFullScreenContent ? 0 : max(screenHeight - visibleHeight - bottomToolBarHeight, 0)
+        topMargin = isFullScreenContent ? 0 : max(screenHeight - layout.settings.minMargin - visibleHeight - bottomToolBarHeight, 0)
         layout.settings.topMargin = topMargin
     }
 

--- a/Sources/Layout/SheetLayoutSettings.swift
+++ b/Sources/Layout/SheetLayoutSettings.swift
@@ -11,6 +11,8 @@ import UIKit
 public struct SheetLayoutSettings {
 
     var topMargin: CGFloat = 0
+
+    var minMargin: CGFloat = 0
     
     /// Whether the header view is stiky. Defaults to true
     public var isHeaderStretchy = true

--- a/Sources/Layout/SheetLayoutSettings.swift
+++ b/Sources/Layout/SheetLayoutSettings.swift
@@ -12,7 +12,7 @@ public struct SheetLayoutSettings {
 
     var topMargin: CGFloat = 0
 
-    var minMargin: CGFloat = 0
+    public var minTopMargin: CGFloat = 0
     
     /// Whether the header view is stiky. Defaults to true
     public var isHeaderStretchy = true


### PR DESCRIPTION
### Issue
sheetNavigationController의 modal presentStyle이 .fullScreen 혹은 .overFullScreen이 아닌 경우가 있을 수 있습니다.
topMargin 계산 시에 screenHeight를 UIScreen.main.bounds.height로 일괄 적용하고 있어서 modal presentStyle이 full이 되지 않는 경우에는 topMargin이 더 크게 계산되는 경우가 있습니다.

### 수정사항
topMargin의 visibleHeight 계산시 minMargin 값을 셋팅하여 빼줍니다.